### PR TITLE
feature/task_header_status

### DIFF
--- a/app/assets/stylesheets/settings/_colors.scss
+++ b/app/assets/stylesheets/settings/_colors.scss
@@ -2,7 +2,6 @@
 
 $black         : #2C4C5E;
 $green         : #009E11;
-$blue          : #4A90E2;
 $red           : #D0021B;
 $cream         : #FFF9ED;
 $grey          : #9B9B9B;
@@ -14,6 +13,7 @@ $white         : #FFFFFF;
 $offwhite      : #EEEEEE;
 
 
+$blue-darkish  : #4A90E2;
 $blue          : #00B8D4;
 $blue-dark-1   : #546E7A;
 $blue-dark-2   : #263238;

--- a/app/assets/stylesheets/views/circle/tasks/task.scss
+++ b/app/assets/stylesheets/views/circle/tasks/task.scss
@@ -209,3 +209,28 @@ section > .task.complete {
     }
   }
 }
+
+section > .task.full {
+  .task-header {
+    .date {
+      .month {
+        background-color: $blue-darkish;
+        color: $white;
+      }
+
+      .day {
+        border-color: $blue-500;
+      }
+
+    }
+    .title {
+      background-color: $blue-500;
+      color: $blue-50;
+    }
+
+    .description {
+      background-color: $blue-50;
+      color: $blue-500;
+    }
+  }
+}

--- a/app/controllers/circle/tasks_controller.rb
+++ b/app/controllers/circle/tasks_controller.rb
@@ -178,7 +178,7 @@ class Circle::TasksController < ApplicationController
       page.is_missing_volunteers = current_task.volunteer_count_required > current_task.volunteers.size
       page.missing_volunteer_count = current_task.volunteer_count_required - current_task.volunteers.size
       page.adjusted_missing_volunteer_count = can?(:volunteer, current_task) ? page.missing_volunteer_count - 1 : page.missing_volunteer_count
-      page.task_css = "complete" if current_task.complete?
+      page.task_css = ('complete' if current_task.complete?) || ('full' if !page.is_missing_volunteers) || ''
     end
   end
 


### PR DESCRIPTION
Set header color to 'blue' if task is fully staffed with volunteers. #76