### PR TITLE
Added env tag to footer of sidebar

### DIFF
--- a/app/views/layouts/internal/_sidebar.slim
+++ b/app/views/layouts/internal/_sidebar.slim
@@ -42,3 +42,5 @@ nav
       = t('supported-by')
       .logo
       = t('lale')
+      - if !Rails.env.production?
+        p= Rails.application.config.env_indicator

--- a/config/initializers/env_indicator.rb
+++ b/config/initializers/env_indicator.rb
@@ -1,0 +1,3 @@
+git_sha = (ENV['HEROKU_SLUG_COMMIT'] || `git rev-parse --short HEAD`)[0..6]
+env_tag = Rails.env + '-' + git_sha
+Rails.application.config.env_indicator = env_tag


### PR DESCRIPTION
#220 

Env tag does not show up in the sign-up menu, not sure if we want it to appear there as well

<img width="1438" alt="screen shot 2016-03-17 at 4 43 48 pm" src="https://cloud.githubusercontent.com/assets/1487616/13864654/aa7d7e52-ec60-11e5-9251-9a78171caf03.png">
