### PR TITLE
Admins can now see pending users

### DIFF
--- a/app/controllers/circle/members_controller.rb
+++ b/app/controllers/circle/members_controller.rb
@@ -23,7 +23,7 @@ class Circle::MembersController < ApplicationController
   end
 
   helper_method def current_member
-    @current_member ||= current_circle.users.active.find(params[:id])
+    @current_member ||= current_circle.users.find(params[:id])
   end
 
   private 


### PR DESCRIPTION
#225 

Seems like we were checking for active users even though the users in question were not yet active.

![ezgif com-gif-maker](https://cloud.githubusercontent.com/assets/1487616/13865036/2b28d288-ec64-11e5-9f15-b59c2d347ed3.gif)
