### PR TITLE
Pending users no longer show up as possible work group organizer

### DIFF
--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -7,7 +7,6 @@ class Circle < ActiveRecord::Base
   has_many :officials,  -> { Role.send('circle.official').extending(UserAssociationExtension)  }, through: :roles, source: :user
   has_many :volunteers, -> { Role.send('circle.volunteer').extending(UserAssociationExtension) }, through: :roles, source: :user
   has_many :leadership, -> { Role.leadership.extending(UserAssociationExtension)               }, through: :roles, source: :user
-  
   has_many :organizers, -> { distinct }, through: :working_groups, source: :admins
 
   has_many :working_groups
@@ -33,6 +32,10 @@ class Circle < ActiveRecord::Base
 
   def active_organizers
     organizers.joins(:circle_roles).where(circle_roles: { status: Circle::Role.statuses[:active] })
+  end
+
+  def active_users
+    users.joins(:circle_roles).where(circle_roles: { status: Circle::Role.statuses[:active] })
   end
 
   def admin

--- a/app/mutations/working_group/base_form.rb
+++ b/app/mutations/working_group/base_form.rb
@@ -24,7 +24,7 @@ class WorkingGroup::BaseForm < ::Form
   end
 
   def organizer_options
-    working_group.circle.users.order(:first_name).map { |u| [u.name, u.id] }
+    working_group.circle.active_users.order(:first_name).map { |u| [u.name, u.id] }
   end
 
   def organizer_assignable?


### PR DESCRIPTION
#372 

Hopefully I addressed the bug in question!
Created a helper method to return all active users, and substituted that into the method returning possible users for working group organizers