### PR TITLE
Organizers of inactive working groups can no longer see the 'Add' button

### DIFF
--- a/app/permissions/ability.rb
+++ b/app/permissions/ability.rb
@@ -60,6 +60,7 @@ class Ability
       can?(:create_supply, circle)
     end
     cannot :create_item, Circle do |circle|
+      !circle.working_groups.any? { |wg| wg.active_admins.include?(user) && wg.active? } or
       !can?(:create_task, circle)
     end
 


### PR DESCRIPTION
#363 

Problem: A user who is not an organizer of at least 1 active working group should not see the `add` button.

Proposed solution: I added a check in `ability.rb` under `cannot :create_item` to see if a user is an active admin of at least one active working group. If not, then `cannot :create_item` returns `true`