### PR TITLE
The number of projects and documents shows up in the wg header

### DIFF
--- a/app/controllers/circle/working_groups_controller.rb
+++ b/app/controllers/circle/working_groups_controller.rb
@@ -34,14 +34,16 @@ class Circle::WorkingGroupsController < ApplicationController
     authorize! :read, current_working_group
 
     @files              = current_working_group.files.select { |f| can?(:read, f) }
-    
+
     tasks               = current_working_group.tasks.not_in_project.ordered_by_date
     @open_tasks         = tasks.not_completed.select { |f| can?(:read, f) }
     @completed_tasks    = tasks.completed.select { |f| can?(:read, f) }
-    
+
     supplies            = current_working_group.supplies.not_in_project.ordered_by_date
     @open_supplies      = supplies.not_completed.select { |f| can?(:read, f) }
     @completed_supplies = supplies.completed.select { |f| can?(:read, f) }
+
+    @projects            = current_working_group.projects
   end
 
   def edit

--- a/app/views/circle/working_groups/_nav.slim
+++ b/app/views/circle/working_groups/_nav.slim
@@ -8,7 +8,9 @@
     span.badge = @open_supplies.count
   a.projects data-tab='projects'
     = Project.model_name.human(count: 2)
+    span.badge = @projects.count
   - if feature_enabled? :working_group_files
     a.documents data-tab='documents'
       = t('.documents')
+      span.badge = @files.count
 


### PR DESCRIPTION
#378 

Thanks to the given modular code, the additions were very simple 👍 

<img width="696" alt="screen shot 2016-07-05 at 10 49 24 am" src="https://cloud.githubusercontent.com/assets/1487616/16594600/0a255c18-42a0-11e6-9998-efebfebc179f.png">

<img width="686" alt="screen shot 2016-07-05 at 10 49 20 am" src="https://cloud.githubusercontent.com/assets/1487616/16594602/0b856788-42a0-11e6-9ba7-b05439e5a9a6.png">
