### PR TITLE
The Helper List can now be translated into a PDF

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'geocoder'
 gem 'timezone'
 gem 'terminal-table'
 gem 'country_select'
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
 
 group :development do
   gem "letter_opener_web"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,6 +436,8 @@ GEM
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    wicked_pdf (1.1.0)
+    wkhtmltopdf-binary (0.12.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -508,6 +510,11 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
+  wicked_pdf
+  wkhtmltopdf-binary
+
+RUBY VERSION
+   ruby 2.2.3p173
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/app/assets/stylesheets/views/circle/members/members_list.scss
+++ b/app/assets/stylesheets/views/circle/members/members_list.scss
@@ -21,3 +21,7 @@ section > .members_list {
     white-space: nowrap;
   }
 }
+
+tr {
+  page-break-inside: avoid
+}

--- a/app/controllers/circle/members_controller.rb
+++ b/app/controllers/circle/members_controller.rb
@@ -14,6 +14,16 @@ class Circle::MembersController < ApplicationController
     @members    = active_users.select { |member| can?(:read, member, current_circle) }
     @organizers = organizers.select { |member| can?(:read, member, current_circle) }
     @totals     = { members: active_users.count, organizers: organizers.count }
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render  pdf: 'This is the PDF Name',
+                template: 'circle/members/_list.slim',
+                layout: 'pdf.slim',
+                locals: { members: @members },
+                orientation: 'Landscape'
+      end
+    end
   end
 
   def show
@@ -51,7 +61,7 @@ class Circle::MembersController < ApplicationController
       redirect_to circle_member_path(current_circle, current_member)
     end
   end
-  
+
 
   def block
     authorize! :block, current_member, current_circle

--- a/app/views/circle/members/_list.slim
+++ b/app/views/circle/members/_list.slim
@@ -24,16 +24,16 @@ table.member-list.default-table
       tr
         td
           == cell(:user_icon, user, circle: current_circle, link: true)
-        
+
         td.name
           = link_to(user.name, circle_member_path(current_circle, user))
-        
+
         td
           - wg_links = user.working_groups.for_circle(current_circle).map { |wg| link_to(html_escape(wg.name), circle_working_group_path(current_circle,wg)) }
           = wg_links.join(', </br>').html_safe
         td
           = user.address.full_address
-        
+
         td.no-wrap
           - if user.mobile_phone.present?
             div = "M: #{user.mobile_phone}"

--- a/app/views/circle/members/index.slim
+++ b/app/views/circle/members/index.slim
@@ -3,6 +3,8 @@
   = render 'nav'
 
   .tab.helpers
+    - if can? :manage, current_circle
+      = link_to("PDF", circle_members_path(format: 'pdf'), target: "_blank", class: "button showing", format: :pdf)
     = render partial: 'list', locals: { members: @members }
     .showing
       = t('.total_members', total: @totals[:members], showing: @members.length)

--- a/app/views/layouts/pdf.slim
+++ b/app/views/layouts/pdf.slim
@@ -1,0 +1,9 @@
+doctype html
+html
+  head
+    meta content=("text/html; charset=UTF-8") http-equiv="Content-Type" /
+    title PDF
+    = wicked_pdf_stylesheet_link_tag "application"
+  body
+    .container
+      = yield


### PR DESCRIPTION
# 235

PDF generation works for Admins for the Helper List, although the table is a bit ugly with all the info on it. It's easy to make a pdf-specific layout if desired. 
Also I keep getting a weird error in the terminal (though it doesn't seem to affect any functionality):

https://gist.github.com/NolanChan/18435cebaa0d70bbe6bbb68c162e7f9d

Please let me know if you see it, and any feedback 😀

![pdf_helper_list](https://cloud.githubusercontent.com/assets/1487616/19630741/9192fe5c-9945-11e6-8ce6-7d33ba539a2d.gif)
