### PR TITLE
Fixed flash message translation for closing task

### DIFF
--- a/app/controllers/circle/tasks_controller.rb
+++ b/app/controllers/circle/tasks_controller.rb
@@ -106,7 +106,7 @@ class Circle::TasksController < ApplicationController
 
     outcome = Task::Volunteer.run(user: current_user, task: current_task)
 
-    set_flash(outcome.success? ? :success : :error, name: current_user.name)
+    set_flash(outcome.success? ? :success : :error, name: current_task.name)
     redirect_to circle_task_path(current_circle, current_task)
   end
 
@@ -151,7 +151,7 @@ class Circle::TasksController < ApplicationController
 
     outcome = Task::Decline.run(user: current_user, task: current_task)
 
-    set_flash(outcome.success? ? :success : :error)
+    set_flash(outcome.success? ? :success : :error, name: current_task.name)
     redirect_to circle_task_path(current_circle, current_task)
   end
 

--- a/app/controllers/circle/tasks_controller.rb
+++ b/app/controllers/circle/tasks_controller.rb
@@ -106,7 +106,7 @@ class Circle::TasksController < ApplicationController
 
     outcome = Task::Volunteer.run(user: current_user, task: current_task)
 
-    set_flash(outcome.success? ? :success : :error)
+    set_flash(outcome.success? ? :success : :error, name: current_user.name)
     redirect_to circle_task_path(current_circle, current_task)
   end
 
@@ -161,7 +161,7 @@ class Circle::TasksController < ApplicationController
 
     outcome = Task::Complete.run(user: current_user, task: current_task)
 
-    set_flash(outcome.success? ? :success : :error)
+    set_flash(outcome.success? ? :success : :error, name: current_task.name)
     redirect_to circle_task_path(current_circle, current_task)
   end
 


### PR DESCRIPTION
Fix for issue #418, it was also happening when volunteering for a task. 

<img width="1911" alt="volunteer" src="https://cloud.githubusercontent.com/assets/4204139/20504041/bf2e1ce0-b045-11e6-90a5-93253e0bf94d.png">

Screenshots of fixed flash messages:

<img width="1910" alt="volunteer_fixed2" src="https://cloud.githubusercontent.com/assets/4204139/20504948/712f0af4-b04a-11e6-8111-0d86affcaf2f.png">

<img width="1905" alt="completetask_fixed" src="https://cloud.githubusercontent.com/assets/4204139/20504048/d193a616-b045-11e6-9fe7-fc26f59c3ea0.png">
 