### PR TITLE
Removed default location for new task/supply

### DIFF
--- a/app/mutations/supply/base_form.rb
+++ b/app/mutations/supply/base_form.rb
@@ -7,7 +7,7 @@ class Supply::BaseForm < ::Form
   attribute :due_date,         :date,   default: proc{ Date.today + 1.week }
   attribute :description,      :string
 
-  attribute :location, :string, default: proc{ (supply.location || circle.address.location).try :address }
+  attribute :location, :string, default: proc{ supply.location.try :address }
   attribute :organizer_id,     :integer, default: proc { supply.organizer.try(:id) || user.id }
 
   attribute :ability, :model

--- a/app/mutations/task/base_form.rb
+++ b/app/mutations/task/base_form.rb
@@ -5,7 +5,7 @@ class Task::BaseForm < ::Form
   attribute :name,             :string
   attribute :description,      :string
 
-  attribute :primary_location, :string, default: proc { (task.primary_location || circle.address.location).try(:address) }
+  attribute :primary_location, :string, default: proc { task.primary_location.try :address }
   attribute :organizer_id,     :integer, default: proc { task.organizer.try(:id) || user.id }
 
   attribute :duration,      :integer


### PR DESCRIPTION
Fixes #428 
Besides tasks, I've noticed that supply also had a default value, so I've also changed the task to leave it empty when creating a new supply.