### PR TITLE
Increased description field size limit

### DIFF
--- a/app/assets/stylesheets/views/circle/show.scss
+++ b/app/assets/stylesheets/views/circle/show.scss
@@ -5,5 +5,11 @@
         @include lale-icon($lale-icon-circle, 1.25em);
       }
     }
+    .description {
+        overflow-y: auto; 
+        max-height: 3.5em;
+        text-align: justify;
+        text-justify: inter-word; 
+    }
   }
 }

--- a/app/assets/stylesheets/views/circle/working_groups/show.scss
+++ b/app/assets/stylesheets/views/circle/working_groups/show.scss
@@ -7,6 +7,12 @@
         }
       }
     }
+    .description {
+        overflow-y: auto; 
+        max-height: 3.5em;
+        text-align: justify;
+        text-justify: inter-word; 
+    }
   }
 
   // it's much easier to hide the message (which should be hidden ) with CSS

--- a/app/views/circle/working_groups/_form.slim
+++ b/app/views/circle/working_groups/_form.slim
@@ -12,7 +12,7 @@
   .field-row
     .field
       = f.label :description
-      = f.text_area :description, {maxlength: 200}
+      = f.text_area :description, {maxlength: 2000}
       = errors.formatted_message_for(:description)
 
   .field-row

--- a/app/views/circles/_form.slim
+++ b/app/views/circles/_form.slim
@@ -19,7 +19,7 @@
   .field-row
     .field
       = f.label :description
-      = f.text_area :description, {maxlength: 200}
+      = f.text_area :description, {maxlength: 2000}
       = errors.formatted_message_for(:description)
 
 


### PR DESCRIPTION
Fixes #419 
This increases the size limit for description fields on Circle and Working Groups.
We have to test how the scroll behaves on mobile and on IE browser. 