### PR TITLE
Left Navigation Working Group Listing Is Now Sorted Alphabetically

### DIFF
--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -59,7 +59,7 @@ module SidebarHelper
   private
 
   def working_groups_per_user(check_method)
-    current_circle.working_groups.active.select do |wg|
+    current_circle.working_groups.active.asc_order.select do |wg|
       current_user.working_groups.map(&:id).send(check_method, wg.id)
     end
   end


### PR DESCRIPTION
#434 

Pretty simple fix 👍 . I placed it in the code where I thought it would make the most sense (in the controller vs. view) that would require the least amount of rewritten code (in the helper method before the `select` block because `asc_order` doesn't work inside the `select` block)