### PR TITLE
Working Group Prompt is now sorted by last name alphabetically

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User < ActiveRecord::Base
 
   enum language: [:en, :de, :fr]
 
+  scope :asc_order, -> { order(:last_name) }
+
   alias_attribute :active_since, :created_at
 
   class << self
@@ -58,6 +60,10 @@ class User < ActiveRecord::Base
 
   def name
     "#{first_name} #{last_name}"
+  end
+
+  def list_name
+    "#{last_name}, #{first_name}"
   end
 
   def email

--- a/app/views/circle/working_groups/_add_user_form.slim
+++ b/app/views/circle/working_groups/_add_user_form.slim
@@ -4,7 +4,7 @@
 
     .field-row
       .field
-        = f.collection_select :user_id, form.available_users, :id, :name
+        = f.collection_select :user_id, form.available_users.asc_order, :id, :list_name
 
       .field
         = f.submit t('.add'), class: 'button-primary'

--- a/spec/features/working_groups/add_and_remove_working_group_organizers_spec.rb
+++ b/spec/features/working_groups/add_and_remove_working_group_organizers_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe "Add and remove working group organizers", js: true do
-  
+
   let(:circle)        { create(:circle, :with_admin_and_working_group) }
   let(:admin)         { circle.admin }
   let(:working_group) { circle.working_groups.first }
 
-  let(:roles_page) { PageObject::WorkingGroup::Roles.new(circle, working_group, admin) }  
+  let(:roles_page) { PageObject::WorkingGroup::Roles.new(circle, working_group, admin) }
 
   describe "add" do
 
@@ -16,18 +16,18 @@ describe "Add and remove working group organizers", js: true do
 
       before { roles_page.load_for(:organizers) }
       before { expect(roles_page).to have_no_users }
-      
+
       it "can be added" do
-        roles_page.user_dropdown.select(circle_member.name)
-        # For a reason I wasn't able to debug in half a day, the div.field-row which contains the button 
+        roles_page.user_dropdown.select(circle_member.list_name)
+        # For a reason I wasn't able to debug in half a day, the div.field-row which contains the button
         # has a "display:none", but only in the test. So a regular .click can't access the button since
         # it is not visible. This will not work with selenium, though
         roles_page.add_button.trigger(:click)
         # wait for the page to update. normally I would use
         # roles_page.wait_for_users but since we're still on the same page after the reload,
         # that would immediately trigger true and continue.
-        sleep 1 
-        expect(roles_page.organizers).to eq([circle_member.name])
+        sleep 1
+        expect(roles_page.organizers).to eq([circle_member.list_name])
       end
     end
   end
@@ -37,7 +37,7 @@ describe "Add and remove working group organizers", js: true do
     context "working group has two organizers" do
 
       let!(:organizers) do
-        create_list(:working_group_organizer_role, 2, working_group: working_group).map do |role| 
+        create_list(:working_group_organizer_role, 2, working_group: working_group).map do |role|
           role.user
         end
       end

--- a/spec/features/working_groups/add_and_remove_working_group_volunteers_spec.rb
+++ b/spec/features/working_groups/add_and_remove_working_group_volunteers_spec.rb
@@ -1,33 +1,33 @@
 require 'rails_helper'
 
 describe "Add and remove working group volunteers", js: true do
-  
+
   let(:circle)        { create(:circle, :with_admin_and_working_group) }
   let(:admin)         { circle.admin }
   let(:working_group) { circle.working_groups.first }
 
-  let(:roles_page) { PageObject::WorkingGroup::Roles.new(circle, working_group, admin) }  
+  let(:roles_page) { PageObject::WorkingGroup::Roles.new(circle, working_group, admin) }
 
   describe "add" do
-  
+
     context "circle has a member that's not in the working group yet" do
 
       let!(:circle_member) { create(:circle_role_volunteer, circle: circle).user }
 
       before { roles_page.load_for(:members) }
       before { expect(roles_page.volunteers).to eq([admin.name]) }
-      
+
       it "can be added" do
-        roles_page.user_dropdown.select(circle_member.name)
-        # For a reason I wasn't able to debug in half a day, the div.field-row which contains the button 
+        roles_page.user_dropdown.select(circle_member.list_name)
+        # For a reason I wasn't able to debug in half a day, the div.field-row which contains the button
         # has a "display:none", but only in the test. So a regular .click can't access the button since
         # it is not visible.
         roles_page.add_button.trigger(:click)
         # wait for the page to update. normally I would use
         # roles_page.wait_for_users but since we're still on the same page after the reload,
         # that would immediately trigger true and continue.
-        sleep 1 
-        expect(roles_page.volunteers).to eq([admin.name, circle_member.name])
+        sleep 1
+        expect(roles_page.volunteers).to eq([admin.name, circle_member.list_name])
       end
     end
   end


### PR DESCRIPTION
#435 

The working group prompt is now sorted by last name with format 'last name, first name'
The actual list of organisers isn't sorted, but that's an easy addition too if needed