### PR TITLE
User is prompted with warning of closing all supplies and tasks when completing project

### DIFF
--- a/app/controllers/circle/projects_controller.rb
+++ b/app/controllers/circle/projects_controller.rb
@@ -61,6 +61,7 @@ class Circle::ProjectsController < ApplicationController
 
   def complete
     authorize! :complete, current_project
+    close_all_tasks_supplies
     outcome = Project::Complete.run(project: current_project)
     set_flash(outcome.success? ? :success : :error)
     redirect_to circle_project_path(current_circle, current_project)
@@ -98,6 +99,11 @@ class Circle::ProjectsController < ApplicationController
 
   helper_method def current_project
     @project ||= current_circle.projects.find(params[:id] || params[:project_id])
+  end
+
+  def close_all_tasks_supplies
+    current_project.tasks.incomplete.map {|t| Task::Complete.run(user: current_user, task: t)}
+    current_project.supplies.incomplete.map {|s| Supply::Complete.run(user: current_user, supply: s)}
   end
 
 end

--- a/app/presenters/project_presenter.rb
+++ b/app/presenters/project_presenter.rb
@@ -108,15 +108,15 @@ class ProjectPresenter < Presenter
 
   def link_to_complete
     options = {}
+    options[:method] = :put
     if has_incomplete_items?
-      options[:onclick] = "alert(#{I18n.t('circle.projects.show.cant_complete_with_items').to_json}); return false;"
+      context.link_to(circle_project_complete_path(_.circle, _), data: {confirm: I18n.t('helpers.confirm.project.complete')}, method: 'put') do
+        yield
+      end
     else
-      # this will submit the form anyhow even if onclick returns false, so only add it when
-      # the link really should be followed.
-      options[:method] = :put
-    end
-    context.link_to(circle_project_complete_path(_.circle, _), options) do
-      yield
+      context.link_to(circle_project_complete_path(_.circle, _), options) do
+        yield
+      end
     end
 
   end

--- a/app/views/circle/projects/_edit_actions.slim
+++ b/app/views/circle/projects/_edit_actions.slim
@@ -1,7 +1,7 @@
 .dropdown.project-edit-menu
-  
-  / showing/hiding the dropdown menu is implemented with CSS only. 
-  / the checked state of this checkbox controls which CSS rules are applied to the 
+
+  / showing/hiding the dropdown menu is implemented with CSS only.
+  / the checked state of this checkbox controls which CSS rules are applied to the
   / menu, thus toggling it's visiblity.
   input id='project-edit-selector' type='checkbox' class='menu-selector'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1020,6 +1020,7 @@
     :complete: Complete %{model}
     :confirm:
       :project:
+        :complete: This project still has open tasks or supplies. Do you really want to close them all as well?
         :delete: Really delete this project and all it's tasks?
       :supply:
         :delete: Are you sure you want to delete this supply?


### PR DESCRIPTION
#440 

Some assumptions I made with my PR:

- I edited the projects#complete action and made sure that whenever this action is called, all incomplete tasks and supplies are also closed. I assume that every time a project is closed, it's associated tasks/supplies must also be closed
- I replaced the javascript alert with a regular rails confirm dialog to ask the user
- Because I'm using the regular rails confirm dialog, I'm unable to edit the buttons to become "cancel" and "continue" unless I use a lot more javascript. If this is desired, I can do it 