### PR TITLE
Projects now have start end date 

### DIFF
--- a/app/assets/javascripts/views/circles/projects/form.coffee
+++ b/app/assets/javascripts/views/circles/projects/form.coffee
@@ -1,5 +1,52 @@
+class Lale.Date
+  constructor: (date_field)->
+    # after init, the input element is still empty,
+    # but the datepicker getValue call can already return a valid date object
+    @dateFilled = date_field.val() != ''
+    @value = this.buildDate(date_field)
+
+  buildDate: (date_field)->
+    date = this.parseDate(date_field)
+    if !date then null else date
+
+  valid:->
+    # took out `&& (@value instanceof Date)` because it was always returning false
+    @dateFilled
+
+  parseDate: (field)->
+    field.datetimepicker('getValue')
+
 ready = ->
-  new Lale.WorkgroupDependentSelect('#project_working_group_id', '#project_organizer_id', {hideOnEmpty: false})
+
+  initDatePickers = ->
+    # http://xdsoft.net/jqplugins/datetimepicker/
+    $.datetimepicker.setLocale(I18n.locale);
+
+    # using .xd_datepicker since active admin binds it's a jQuery UI datepicker
+    # to all .datepicker classes, which causes two datepickers to appear.
+    $('.xd_datepicker').datetimepicker({
+      timepicker:     false,
+      dayOfWeekStart: I18n.t('datepicker.day_of_week_start'),
+      format:         I18n.t('datepicker.date_format'),
+      minDate:        0,
+      scrollMonth:    false,
+      onChangeDateTime: validateDateTime
+    });
+
+  validateDateTime = ->
+    start = new Lale.Date($('#project_start_date_string'))
+    due   = new Lale.Date($('#project_due_date_string'))
+
+    # when start date is after due date, set them both to start date
+    if start.valid() && due.valid() && (start.value > due.value)
+      $('#project_due_date_string').val($('#project_start_date_string').val())
+
+  init = ->
+    initDatePickers()
+
+    new Lale.WorkgroupDependentSelect('#project_working_group_id', '#project_organizer_id', {hideOnEmpty: false})
+
+  init()
 
 $(document).on 'ready', ready
 $(document).on 'page:load', ready

--- a/app/assets/javascripts/views/circles/tasks/form.coffee
+++ b/app/assets/javascripts/views/circles/tasks/form.coffee
@@ -1,6 +1,6 @@
 class Lale.DateTime
   constructor: (date_field, time_field)->
-    # after init, the input element is still empty, 
+    # after init, the input element is still empty,
     # but the datepicker getValue call can already return a valid date object
     @dateFilled = date_field.val() != ''
     @value = this.buildDate(date_field, time_field)
@@ -62,7 +62,7 @@ ready = ->
 
   showOrHideStartDate = ->
     type = $('#task_scheduling_type').val()
-    if type == "between" 
+    if type == "between"
       $('.at-element').hide()
       $('.between-element').show()
     else
@@ -73,7 +73,7 @@ ready = ->
     start = new Lale.DateTime($('#task_start_date_string'), $('#task_start_time'))
     due   = new Lale.DateTime($('#task_due_date_string'), $('#task_due_time'))
 
-    # when start date is before due date, set them both to start date
+    # when start date is after due date, set them both to start date
     if start.valid() && due.valid() && (start.value > due.value)
       $('#task_due_date_string').val($('#task_start_date_string').val())
       $('#task_due_time').val($('#task_start_time').val())
@@ -91,7 +91,7 @@ ready = ->
   # then init
   #
   init()
-  
+
 
 $(document).on 'ready', ready
 $(document).on 'page:load', ready

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,20 +54,20 @@ class Project < ActiveRecord::Base
     admins.select {|admin| circle.has_active_user?(admin) }
   end
 
-  def start_date
-    dates = []
-    dates << tasks.minimum(:start_date)
-    # quick hack: if no task has a start date, use the earliest end date.
-    dates << tasks.minimum(:due_date)
-    dates << supplies.minimum(:due_date)
-    dates.compact.min
-  end
+  # def start_date
+  #   dates = []
+  #   dates << tasks.minimum(:start_date)
+  #   # quick hack: if no task has a start date, use the earliest end date.
+  #   dates << tasks.minimum(:due_date)
+  #   dates << supplies.minimum(:due_date)
+  #   dates.compact.min
+  # end
 
-  def due_date
-    dates = []
-    dates << tasks.maximum(:due_date)
-    dates << supplies.maximum(:due_date)
-    dates.compact.max
-  end
+  # def due_date
+  #   dates = []
+  #   dates << tasks.maximum(:due_date)
+  #   dates << supplies.maximum(:due_date)
+  #   dates.compact.max
+  # end
 
 end

--- a/app/mutations/supply/base_form.rb
+++ b/app/mutations/supply/base_form.rb
@@ -17,6 +17,10 @@ class Supply::BaseForm < ::Form
 
   class Submit < ::Form::Submit
 
+    def end_before_project
+      project && project.due_date && due_date > project.due_date
+    end
+
     def project
       project_id.present? ? Project.find(project_id) : nil
     end
@@ -25,6 +29,7 @@ class Supply::BaseForm < ::Form
       add_error(:name, :too_short)                   if name.length < 5
       add_error(:description, :too_short)            if description.length < 5
       add_error(:due_date, :empty)                   if due_date.blank?
+      add_error(:due_date, :end_before)              if end_before_project
     end
 
     def execute

--- a/app/mutations/task/base_form.rb
+++ b/app/mutations/task/base_form.rb
@@ -62,16 +62,26 @@ class Task::BaseForm < ::Form
 
   class Submit < ::Form::Submit
 
+    def start_after_project
+      project && project.start_date && start_date < project.start_date
+    end
+
+    def end_before_project
+      project && project.due_date && due_date > project.due_date
+    end
+
     TIME_REGEX = /^[0-2]?[0-9]:[0-5][0-9]$/
 
     def validate
       add_error(:name, :too_short)                   if name.length < 5
       add_error(:description, :too_short)            if description.length < 5
       add_error(:due_date, :empty)                   if due_date.blank?
+      add_error(:due_date, :end_before)              if end_before_project
       add_error(:volunteer_count_required, :too_low) if volunteer_count_required < 1
       add_error(:start_time, :format)                if start_time.present? && start_time !~ TIME_REGEX
       add_error(:due_time, :format)                  if due_time.present? && due_time !~ TIME_REGEX
       add_error(:start_date, :empty)                 if scheduling_type == 'between' && start_date.blank?
+      add_error(:start_date, :start_after)           if start_after_project
     end
 
     def execute

--- a/app/views/circle/projects/_form.slim
+++ b/app/views/circle/projects/_form.slim
@@ -3,7 +3,7 @@
   - if errors.present?
     .form-introduction.error
       p = t('error_correction')
-  
+
   .field-row.single
     .field.required class=errors.css(:name)
       = f.label :name
@@ -16,6 +16,16 @@
       = f.label :description
       = f.text_area :description
       = errors.formatted_message_for(:description)
+
+  .field-row
+    .field.required class=errors.css(:start_date)
+        = f.label :start_date
+        = f.text_field :start_date_string, class: :xd_datepicker
+        = errors.formatted_message_for(:start_date)
+
+    .field class=errors.css(:due_date)
+        = f.label :due_date
+        = f.text_field :due_date_string, class: :xd_datepicker
 
   .field-row
     .field.required class=errors.css(:working_group)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -876,6 +876,7 @@
       :too_short: Description is too short
     :due_date:
       :empty: Please enter a due date
+      :end_before: The task must end before the project due date
     :due_time:
       :format: Please enter the due time in the format 00:00.
     :email:
@@ -958,6 +959,7 @@
       :empty: Please enter a location
     :start_date:
       :empty: Start date can't be blank
+      :start_after: The task must start after the project start date
     :start_time:
       :format: Please enter the start time in the format 00:00.
     :unacceptable_request: |

--- a/db/migrate/20170117071814_add_dates_to_projects.rb
+++ b/db/migrate/20170117071814_add_dates_to_projects.rb
@@ -1,0 +1,6 @@
+class AddDatesToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :start_date, :date
+    add_column :projects, :due_date, :date
+  end
+end


### PR DESCRIPTION
Validations included in #330 are implemented as well as the general date functionality:

1. Start date of the project must not in the past
2. End date of the project must be before start
3. All tasks and supplies as part of project should have a due date between start and end of project. Warn when saving task/supply.

Let me know if you have any questions!