### PR TITLE
switch all Mailer to use primitive method parameters

### DIFF
--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,6 +1,8 @@
 class ProjectMailer < BaseMandrillMailer
 
-  def project_invitation(project, user)
+  def project_invitation(project_id, user_id)
+    project = Project.find(project_id)
+    user = User.find(user_id)
     build_message(user.language, user.email) do
       merge_vars(user, project).merge(
         "WORKGROUP"                => project.working_group.name,

--- a/app/mailers/supply_mailer.rb
+++ b/app/mailers/supply_mailer.rb
@@ -1,20 +1,24 @@
 class SupplyMailer < BaseMandrillMailer
-  def supply_completion_reminder(task, user, token)
+  def supply_completion_reminder(task_id, user_id, token_code)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email) do
       merge_vars(user, task).merge({
-        "SUPPLY_MARK_COMPLETE_URL" => handle_token_url(token.code, status: :completed),
-        "SUPPLY_ADD_COMMENT_URL"   => handle_token_url(token.code)
+        "SUPPLY_MARK_COMPLETE_URL" => handle_token_url(token_code, status: :completed),
+        "SUPPLY_ADD_COMMENT_URL"   => handle_token_url(token_code)
       })
     end
   end
 
 
-  def supply_invitation(supply, user, token)
+  def supply_invitation(supply_id, user_id, token_code)
+    supply = Supply.find(supply_id)
+    user = User.find(user_id)
     build_message(user.language, user.email) do
       merge_vars(user, supply).merge({
         "WORKGROUP"         => supply.working_group.name,
-        "SUPPLY_URL"        => handle_token_url(token.code),
-        "SUPPLY_ACCEPT_URL" => handle_token_url(token.code, status: :accept),
+        "SUPPLY_URL"        => handle_token_url(token_code),
+        "SUPPLY_ACCEPT_URL" => handle_token_url(token_code, status: :accept),
       })
     end
   end

--- a/app/mailers/task_mailer.rb
+++ b/app/mailers/task_mailer.rb
@@ -1,37 +1,45 @@
 class TaskMailer < BaseMandrillMailer
-  def task_reminder(task, user, token)
+  def task_reminder(task_id, user_id, token_code)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
-        "TASK_UNASSIGN_URL" => handle_token_url(token.code, status: :decline),
-        "TASK_CONFIRM_URL"  => handle_token_url(token.code, status: :confirm)
+        "TASK_UNASSIGN_URL" => handle_token_url(token_code, status: :decline),
+        "TASK_CONFIRM_URL"  => handle_token_url(token_code, status: :confirm)
       )
     end
   end
 
 
-  def task_completion_reminder(task, user, token)
+  def task_completion_reminder(task_id, user_id, token_code)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
-        "TASK_MARK_COMPLETE_URL" => handle_token_url(token.code, status: :completed),
-        "TASK_ADD_COMMENT_URL"   => handle_token_url(token.code)
+        "TASK_MARK_COMPLETE_URL" => handle_token_url(token_code, status: :completed),
+        "TASK_ADD_COMMENT_URL"   => handle_token_url(token_code)
       )
     end
   end
 
 
-  def task_invitation(task, user, token)
+  def task_invitation(task_id, user_id, token_code)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
         "WORKGROUP"        => task.working_group.name,
-        "TASK_URL"         => handle_token_url(token.code),
-        "TASK_ACCEPT_URL"  => handle_token_url(token.code, status: :accept),
-        "TASK_DECLINE_URL" => handle_token_url(token.code, status: :decline)
+        "TASK_URL"         => handle_token_url(token_code),
+        "TASK_ACCEPT_URL"  => handle_token_url(token_code, status: :accept),
+        "TASK_DECLINE_URL" => handle_token_url(token_code, status: :decline)
       )
     end
   end
 
 
-  def task_change(task, user, changes)
+  def task_change(task_id, user_id, changes)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
         "TASK_REVIEW_URL" => handle_token_url(user.login_token.code, redirect: circle_task_url(task.circle, task)),
@@ -40,7 +48,10 @@ class TaskMailer < BaseMandrillMailer
     end
   end
 
-  def task_comment(task, comment, user)
+  def task_comment(task_id, comment_id, user_id)
+    task = Task.find(task_id)
+    comment = Comment.find(comment_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
         "TASK_COMMENT"    => comment.body,
@@ -50,7 +61,9 @@ class TaskMailer < BaseMandrillMailer
     end
   end
 
-  def task_assigned(task, user)
+  def task_assigned(task_id, user_id)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
         "WORKGROUP"       => task.working_group.name,
@@ -59,7 +72,9 @@ class TaskMailer < BaseMandrillMailer
     end
   end
 
-  def task_unassigned(task, user)
+  def task_unassigned(task_id, user_id)
+    task = Task.find(task_id)
+    user = User.find(user_id)
     build_message(user.language, user.email, task.organizer.try(:email)) do
       merge_vars(user, task).merge(
         "WORKGROUP"       => task.working_group.name,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,22 +1,25 @@
 class UserMailer < BaseMandrillMailer
 
-  def forgot_password(user, token)
+  def forgot_password(user_id, token_code)
+    user = User.find(user_id)
     build_message(user.language, user.email) do
       {
         "FIRST_NAME"         => user.first_name,
         "LAST_NAME"          => user.last_name,
-        "RESET_PASSWORD_URL" => handle_token_url(token.code)
+        "RESET_PASSWORD_URL" => handle_token_url(token_code)
       }
     end
   end
 
   # sent to circle admins when new users want to join
-  def account_activation(circle, user, token) 
+  def account_activation(circle_id, user_id, token_code)
+    circle = Circle.find(circle_id)
+    user = User.find(user_id)
     build_message(user.language, user.email) do
       {
         "FIRST_NAME"          => user.first_name,
         "HELPER_CIRCLE"       => circle.name,
-        "APPROVE_REQUEST_URL" => handle_token_url(token.code, 
+        "APPROVE_REQUEST_URL" => handle_token_url(token_code,
           redirect: invite_circle_admin_url(circle)
         )
       }
@@ -24,7 +27,9 @@ class UserMailer < BaseMandrillMailer
   end
 
   # sent to new circle member when account was activated
-  def account_activated(circle, user)
+  def account_activated(circle_id, user_id)
+    circle = Circle.find(circle_id)
+    user = User.find(user_id)
     build_message(user.language, user.email) do
       {
         "FIRST_NAME"       => user.first_name,

--- a/app/mutations/circle/join.rb
+++ b/app/mutations/circle/join.rb
@@ -29,7 +29,7 @@ class Circle::Join < ::Form
     def notify_circle_admins
       circle.admins.active.each do |admin|
         token = Token.login.create!(context: { user_id: admin.id })
-        UserMailer.delay.account_activation(circle, admin, token)
+        UserMailer.delay.account_activation(circle.id, admin.id, token.code)
       end
     end
 

--- a/app/mutations/circle/member/activate.rb
+++ b/app/mutations/circle/member/activate.rb
@@ -9,7 +9,7 @@ class Circle::Member::Activate < Circle::Member::ChangeStatus
   private
 
   def notify_user
-    UserMailer.delay.account_activated(circle, user)
+    UserMailer.delay.account_activated(circle.id, user.id)
   end
 
 end

--- a/app/mutations/comment/create.rb
+++ b/app/mutations/comment/create.rb
@@ -3,9 +3,9 @@ class Comment::Create < Comment::BaseForm
     def execute
       super.tap do |outcome|
         if item.is_a? Task
-          (item.users.uniq - [ commenter ]).each do |outboud_user|
-            next unless outboud_user.email.present?
-            TaskMailer.delay.task_comment(item, comment, outboud_user)
+          (item.users.uniq - [ commenter ]).each do |outbound_user|
+            next unless outbound_user.email.present?
+            TaskMailer.delay.task_comment(item.id, comment.id, outbound_user.id)
           end
         end
       end

--- a/app/mutations/project/notifications/invitation_email.rb
+++ b/app/mutations/project/notifications/invitation_email.rb
@@ -8,7 +8,7 @@ class Project::Notifications::InvitationEmail < Mutations::Command
   def execute
     volunteers.each do |user|
       next unless user.email.present?
-      ProjectMailer.delay.project_invitation(project, user)
+      ProjectMailer.delay.project_invitation(project.id, user.id)
     end
 
     OpenStruct.new(volunteers: volunteers)

--- a/app/mutations/supply/notifications/completion_reminder_email.rb
+++ b/app/mutations/supply/notifications/completion_reminder_email.rb
@@ -7,7 +7,7 @@ class Supply::Notifications::CompletionReminderEmail < Mutations::Command
     [supply.volunteer].compact.each do |user|
       next unless user.email.present?
       token = Token.supply_completion.create! context: { user_id: user.id, supply_id: supply.id }
-      SupplyMailer.delay.supply_completion_reminder(supply, user, token)
+      SupplyMailer.delay.supply_completion_reminder(supply.id, user.id, token.code)
     end
   end
 end

--- a/app/mutations/supply/notifications/invitation_email.rb
+++ b/app/mutations/supply/notifications/invitation_email.rb
@@ -8,7 +8,7 @@ class Supply::Notifications::InvitationEmail < Mutations::Command
   def execute
     invitees.each do |user|
       token = Token.supply_invitation.create! context: { user_id: user.id, supply_id: supply.id }
-      SupplyMailer.delay.supply_invitation(supply, user, token)
+      SupplyMailer.delay.supply_invitation(supply.id, user.id, token.code)
     end
 
     Task::Comments::Invited.run(item: supply, user: current_user, invite_count: invitees.count)

--- a/app/mutations/task/assign.rb
+++ b/app/mutations/task/assign.rb
@@ -34,13 +34,13 @@ class Task::Assign < Mutations::Command
   def notify_existing_volunteers
     existing_volunteers.each do |volunteer|
       changes = { volunteers: [] } # a slight hack; only the key is relevant
-      TaskMailer.delay.task_change(task, volunteer, changes)
+      TaskMailer.delay.task_change(task.id, volunteer.id, changes)
     end
   end
 
   def notify_new_assignees
     (users - [current_user]).each do |user|
-      TaskMailer.delay.task_assigned(task, user)
+      TaskMailer.delay.task_assigned(task.id, user.id)
     end
   end
 

--- a/app/mutations/task/decline.rb
+++ b/app/mutations/task/decline.rb
@@ -14,7 +14,7 @@ class Task::Decline < Mutations::Command
     (task.users.uniq - [ user ]).each do |outbound_user|
       next unless outbound_user.email.present?
       changes = { volunteers: [] } # a slight hack; only the key is relevant
-      TaskMailer.delay.task_change(task, outbound_user, changes)
+      TaskMailer.delay.task_change(task.id, outbound_user.id, changes)
     end
 
     Comment::AutoComment.run(item: task, message: 'user_unassigned_self', user: user)

--- a/app/mutations/task/notifications/completion_reminder_email.rb
+++ b/app/mutations/task/notifications/completion_reminder_email.rb
@@ -8,7 +8,7 @@ class Task::Notifications::CompletionReminderEmail < Mutations::Command
       next unless user.email.present?
       token = Token.task_completion.create! context: { user_id: user.id, task_id: task.id }
 
-      TaskMailer.delay.task_completion_reminder(task, user, token)
+      TaskMailer.delay.task_completion_reminder(task.id, user.id, token.code)
     end
   end
 end

--- a/app/mutations/task/notifications/invitation_email.rb
+++ b/app/mutations/task/notifications/invitation_email.rb
@@ -20,7 +20,7 @@ class Task::Notifications::InvitationEmail < Mutations::Command
   def invite_users
     invitees.each do |user|
       token = Token.task_invitation.create! context: { user_id: user.id, task_id: task.id }
-      TaskMailer.delay.task_invitation(task, user, token)
+      TaskMailer.delay.task_invitation(task.id, user.id, token.code)
     end
   end
 

--- a/app/mutations/task/notifications/reminder_email.rb
+++ b/app/mutations/task/notifications/reminder_email.rb
@@ -9,7 +9,7 @@ class Task::Notifications::ReminderEmail < Mutations::Command
       Token.task_confirmation.for_user_id(user.id).update_all(active: false)
       token    = Token.task_confirmation.create! context: { user_id: user.id, task_id: task.id }
 
-      TaskMailer.delay.task_reminder(task, user, token)
+      TaskMailer.delay.task_reminder(task.id, user.id, token.code)
     end
   end
 end

--- a/app/mutations/task/unassign.rb
+++ b/app/mutations/task/unassign.rb
@@ -34,13 +34,13 @@ class Task::Unassign < Mutations::Command
   def notify_existing_volunteers
     existing_volunteers.each do |volunteer|
       changes = { volunteers: [] } # a slight hack; only the key is relevant
-      TaskMailer.delay.task_change(task, volunteer, changes)
+      TaskMailer.delay.task_change(task.id, volunteer.id, changes)
     end
   end
 
   def notify_unassignees
     (users - [current_user]).each do |user|
-      TaskMailer.delay.task_unassigned(task, user)
+      TaskMailer.delay.task_unassigned(task.id, user.id)
     end
   end
 

--- a/app/mutations/task/update.rb
+++ b/app/mutations/task/update.rb
@@ -13,7 +13,7 @@ class Task::Update < Task::BaseForm
 
     def notify_users
       if send_notifications && task_changes.present?
-        users_to_notify.each { |user| TaskMailer.delay.task_change(task, user, task_changes) }
+        users_to_notify.each { |user| TaskMailer.delay.task_change(task.id, user.id, task_changes) }
       end
     end
 

--- a/app/mutations/task/volunteer.rb
+++ b/app/mutations/task/volunteer.rb
@@ -26,7 +26,7 @@ class Task::Volunteer < Mutations::Command
   def notify_existing_volunteers
     existing_volunteers.each do |user|
       changes = { volunteers: [] } # a slight hack; only the key is relevant
-      TaskMailer.delay.task_change(task, user, changes)
+      TaskMailer.delay.task_change(task.id, user.id, changes)
     end
   end
 

--- a/app/mutations/user/reset_password.rb
+++ b/app/mutations/user/reset_password.rb
@@ -7,7 +7,7 @@ class User::ResetPassword < Mutations::Command
     identity = User::Identity.find_by!(email: email)
     Token.reset_password.for_user_id(identity.user_id).update_all(active: false)
     token    = Token.reset_password.create! context: { user_id: identity.user_id }
-    UserMailer.delay.forgot_password(identity.user, token)
+    UserMailer.delay.forgot_password(identity.user.id, token.code)
 
   rescue ActiveRecord::RecordNotFound
     add_error(:user, :not_found)


### PR DESCRIPTION
and create the AR models inside the method body. this allows to
use the sidekiq `delay` with smooth serialization of all parameters.

fixes #460